### PR TITLE
Fix `simulateBatchOrder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@synfutures/oyster-sdk",
-    "version": "0.2.6",
+    "version": "0.2.7-bugfix-1",
     "description": "SynFutures V3 SDK",
     "author": "SynFutures",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@synfutures/oyster-sdk",
-    "version": "0.2.7-bugfix-1",
+    "version": "0.2.7",
     "description": "SynFutures V3 SDK",
     "author": "SynFutures",
     "license": "MIT",

--- a/src/synfuturesV3Core.ts
+++ b/src/synfuturesV3Core.ts
@@ -1734,8 +1734,16 @@ export class SynFuturesV3 {
         const minOrderValue = pairAccountModel.rootPair.rootInstrument.minOrderValue;
         const minSizes = targetTicks.map((tick) => wdivUp(minOrderValue, TickMath.getWadAtTick(tick)));
         if (sizeDistribution === BatchOrderSizeDistribution.RANDOM) {
+            // check if any baseSize * ratio is less than minSize
+            let needNewRatios = false;
+            for (let i = 0; i < minSizes.length; i++) {
+                if (baseSize.mul(ratios[i]).div(RATIO_BASE).lt(minSizes[i])) {
+                    needNewRatios = true;
+                    break;
+                }
+            }
             // only adjust sizes if possible
-            if (minSizes.reduce((acc, minSize) => acc.add(minSize), ZERO).lt(baseSize)) {
+            if (needNewRatios && minSizes.reduce((acc, minSize) => acc.add(minSize), ZERO).lt(baseSize)) {
                 ratios = this.getBatchOrderRatios(BatchOrderSizeDistribution.FLAT, orderCount);
             }
         }


### PR DESCRIPTION
When using `RANDOM` size distribution, should check first if any sub-order is less than `minSize`, if so, then try to use `FLAT` size distribution.